### PR TITLE
Add Nix flake with NixOS and Home Manager modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,178 @@
+{
+  description = "FakWin - Fake KWin DBus service for KDE 6 compatibility";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      perSystem =
+        {
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          ...
+        }:
+        {
+          packages.default = pkgs.stdenv.mkDerivation rec {
+            pname = "fakwin";
+            version = "1.0.0";
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              pkg-config
+              qt6.wrapQtAppsHook
+            ];
+
+            buildInputs = with pkgs; [
+              qt6.qtbase
+            ];
+
+            cmakeFlags = [
+              "-DCMAKE_BUILD_TYPE=Release"
+            ];
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/bin
+              cp fakwin $out/bin/
+              runHook postInstall
+            '';
+
+            meta = with pkgs.lib; {
+              description = "Fake KWin DBus service so that KDE 6 shutdown/reboot/logout works when not using KWin";
+              homepage = "https://github.com/DMaroo/fakwin";
+              license = licenses.mit;
+              maintainers = [ "DMaroo" ];
+              platforms = platforms.linux;
+            };
+          };
+
+          packages.fakwin = self'.packages.default;
+
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              cmake
+              pkg-config
+              qt6.qtbase
+              qt6.qttools
+              gdb
+            ];
+
+            shellHook = ''
+              echo "FakWin development environment"
+              echo "Build with: mkdir build && cd build && cmake .. && make"
+              echo "Test with: qdbus org.kde.KWin /Session"
+            '';
+          };
+
+        };
+
+      flake = {
+        /**
+          home-manager module
+
+          # Usage
+
+          ```
+          imports = [
+            fakwin.homeManagerModules.default
+          ];
+
+          services.fakwin.enable = true;
+          ```
+        */
+        homeManagerModules.default =
+          {
+            config,
+            lib,
+            pkgs,
+            ...
+          }:
+          with lib;
+          let
+            cfg = config.services.fakwin;
+            package = self.packages.${pkgs.system}.default;
+          in
+          {
+            options.services.fakwin = {
+              enable = mkEnableOption "FakWin fake KWin DBus service";
+            };
+
+            config = mkIf cfg.enable {
+              systemd.user.services.fakwin = {
+                Unit = {
+                  Description = "Plasma Fake KWin dbus interface";
+                  After = [ "multi-user.target" ];
+                };
+                Install = {
+                  WantedBy = [ "default.target" ];
+                };
+                Service = {
+                  ExecStart = "${package}/bin/fakwin";
+                  Slice = "session.slice";
+                  Restart = "on-failure";
+                };
+              };
+            };
+          };
+
+        /**
+          NixOS module
+
+          # Usage
+
+          ```
+          imports = [
+            fakwin.nixosModules.default
+          ];
+
+          services.fakwin.enable = true;
+          ```
+        */
+        nixosModules.default =
+          {
+            config,
+            lib,
+            pkgs,
+            ...
+          }:
+          with lib;
+          let
+            cfg = config.services.fakwin;
+            package = self.packages.${pkgs.system}.default;
+          in
+          {
+            options.services.fakwin = {
+              enable = mkEnableOption "FakWin fake KWin DBus service";
+            };
+
+            config = mkIf cfg.enable {
+              systemd.user.services.fakwin = {
+                enable = true;
+                description = "Plasma Fake KWin dbus interface";
+                after = [ "multi-user.target" ];
+                wantedBy = [ "default.target" ];
+                serviceConfig = {
+                  ExecStart = "${package}/bin/fakwin";
+                  Slice = "session.slice";
+                  Restart = "on-failure";
+                };
+              };
+            };
+          };
+      };
+    };
+}


### PR DESCRIPTION
This PR adds a flake which

- allows building the application using Nix
- exposes `services.fakwin` option for NixOS configuration
- exposes `services.fakwin` option for home-manager configuration

This is inspired and partially based on #3 by @mghesh-yseop.

`flake.nix` in the repo allows Nix users to pull the package along with hm and NixOS modules using Nix itself:

```nix
inputs.fakwin = "github:DMaroo/fakwin";
```

and then import the corresponding (either hm or NixOS) module and enable fakwin service using a simple directive:

```
services.fakwin.enable = true;
```