### PR TITLE
fix: replace `pkgs.system` with `pkgs.stdenv.hostPlatform.system`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
           with lib;
           let
             cfg = config.services.fakwin;
-            package = self.packages.${pkgs.system}.default;
+            package = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           in
           {
             options.services.fakwin = {
@@ -152,7 +152,7 @@
           with lib;
           let
             cfg = config.services.fakwin;
-            package = self.packages.${pkgs.system}.default;
+            package = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           in
           {
             options.services.fakwin = {


### PR DESCRIPTION
Fixed following warning introduced by nixpkgs 25.11

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```
